### PR TITLE
Missing #include <algorithm> for src/main/native/include/OvertureLib/Math/InterpolatingTable/InterpolatingTable.h

### DIFF
--- a/src/main/native/include/OvertureLib/Math/InterpolatingTable/InterpolatingTable.h
+++ b/src/main/native/include/OvertureLib/Math/InterpolatingTable/InterpolatingTable.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include <map>
+#include <algorithm>
 #include <wpi/interpolating_map.h>
 
 template<typename Key, typename Value>


### PR DESCRIPTION
Fixes #19